### PR TITLE
Add definitions of Serial1x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 bootloaders/*/build/
 *~
 git-archive-full.sh
+.vs/

--- a/variants/wio_terminal/variant.cpp
+++ b/variants/wio_terminal/variant.cpp
@@ -90,9 +90,9 @@ const PinDescription g_APinDescription[] =
         //39 MIC INPUT
         {PORTC, 30, PIO_ANALOG, PIN_ATTR_ANALOG_ALT, ADC_Channel12, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_14}, //MIC_INPUT
 
-        //40..41 UART Serial1
-        {PORTB, 26, PIO_SERCOM, (PIN_ATTR_DIGITAL | PIN_ATTR_PWM_F), No_ADC_Channel, TCC1_CH2, NOT_ON_TIMER, EXTERNAL_INT_12}, //UART1_TX, SERCOM2.0
-        {PORTB, 27, PIO_SERCOM, (PIN_ATTR_DIGITAL | PIN_ATTR_PWM_F), No_ADC_Channel, TCC1_CH3, NOT_ON_TIMER, EXTERNAL_INT_13}, //UART1_RX, SERCOM2.1
+        //40..41 UART Serial1 (GPIO Host)
+        {PORTB, 26, PIO_SERCOM, (PIN_ATTR_DIGITAL | PIN_ATTR_PWM_F), No_ADC_Channel, TCC1_CH2, NOT_ON_TIMER, EXTERNAL_INT_12}, //SERCOM2.0
+        {PORTB, 27, PIO_SERCOM, (PIN_ATTR_DIGITAL | PIN_ATTR_PWM_F), No_ADC_Channel, TCC1_CH3, NOT_ON_TIMER, EXTERNAL_INT_13}, //SERCOM2.1
 
         // 42..44 - USB
         {PORTA, 24, PIO_COM, PIN_ATTR_NONE, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_8}, // USB_D-
@@ -183,8 +183,11 @@ const PinDescription g_APinDescription[] =
 
         //91..92 OUTPUT_CTR
         {PORTC, 14, PIO_DIGITAL, PIN_ATTR_DIGITAL, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_14},
-        {PORTC, 15, PIO_DIGITAL, PIN_ATTR_DIGITAL, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_15}
+        {PORTC, 15, PIO_DIGITAL, PIN_ATTR_DIGITAL, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_15},
 
+        //93..94 UART Serial1x (GPIO Device)
+        {PORTB, 26, PIO_SERCOM_ALT, PIN_ATTR_NONE, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_12}, //SERCOM4.1
+        {PORTB, 27, PIO_SERCOM_ALT, PIN_ATTR_NONE, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_13}, //SERCOM4.0
 };
 
 const void *g_apTCInstances[TCC_INST_NUM + TC_INST_NUM] = {TCC0, TCC1, TCC2, TCC3, TCC4, TC0, TC1, TC2, TC3, TC4, TC5, TC6, TC7};
@@ -201,38 +204,7 @@ SERCOM sercom6(SERCOM6);
 SERCOM sercom7(SERCOM7);
 
 Uart Serial1(&SERCOM_SERIAL1, PIN_SERIAL1_RX, PIN_SERIAL1_TX, PAD_SERIAL1_RX, PAD_SERIAL1_TX);
+INTERRUPT_HANDLER_IMPLEMENT_SERIAL1(Serial1)
+
 Uart Serial2(&SERCOM_SERIAL2, PIN_SERIAL2_RX, PIN_SERIAL2_TX, PAD_SERIAL2_RX, PAD_SERIAL2_TX);
-
-void SERCOM1_0_Handler()
-{
-  Serial2.IrqHandler();
-}
-void SERCOM1_1_Handler()
-{
-  Serial2.IrqHandler();
-}
-void SERCOM1_2_Handler()
-{
-  Serial2.IrqHandler();
-}
-void SERCOM1_3_Handler()
-{
-  Serial2.IrqHandler();
-}
-
-void SERCOM2_0_Handler()
-{
-  Serial1.IrqHandler();
-}
-void SERCOM2_1_Handler()
-{
-  Serial1.IrqHandler();
-}
-void SERCOM2_2_Handler()
-{
-  Serial1.IrqHandler();
-}
-void SERCOM2_3_Handler()
-{
-  Serial1.IrqHandler();
-}
+INTERRUPT_HANDLER_IMPLEMENT_SERIAL2(Serial2)

--- a/variants/wio_terminal/variant.h
+++ b/variants/wio_terminal/variant.h
@@ -54,7 +54,7 @@ extern "C"
  *----------------------------------------------------------------------------*/
 
 // Number of pins defined in PinDescription array
-#define PINS_COUNT (93u)
+#define PINS_COUNT (sizeof(g_APinDescription) / sizeof(g_APinDescription[0]))
 #define NUM_DIGITAL_PINS (23u)
 #define NUM_ANALOG_INPUTS (14u)
 #define NUM_ANALOG_OUTPUTS (2u)
@@ -262,12 +262,56 @@ static const uint8_t DAC1 = PIN_DAC1;
  * Serial interfaces
  */
 
-// Serial1
-#define PIN_SERIAL1_RX (41ul)
-#define PIN_SERIAL1_TX (40ul)
+ // Serial1 (GPIO Host)
+#define PIN_SERIAL1_RX (BCM15)
+#define PIN_SERIAL1_TX (BCM14)
 #define PAD_SERIAL1_RX (SERCOM_RX_PAD_1)
 #define PAD_SERIAL1_TX (UART_TX_PAD_0)
 #define SERCOM_SERIAL1 sercom2
+#define INTERRUPT_HANDLER_IMPLEMENT_SERIAL1(uart) \
+	void SERCOM2_0_Handler() \
+	{ \
+		(uart).IrqHandler(); \
+	} \
+	void SERCOM2_1_Handler() \
+	{ \
+		(uart).IrqHandler(); \
+	} \
+	void SERCOM2_2_Handler() \
+	{ \
+		(uart).IrqHandler(); \
+	} \
+	void SERCOM2_3_Handler() \
+	{ \
+		(uart).IrqHandler(); \
+	}
+
+// Serial1x (GPIO Device)
+//  Uart Serial1x(&SERCOM_SERIAL1X, PIN_SERIAL1X_RX, PIN_SERIAL1X_TX, PAD_SERIAL1X_RX, PAD_SERIAL1X_TX);
+//  INTERRUPT_HANDLER_IMPLEMENT_SERIAL1X(Serial1x)
+
+#define PIN_SERIAL1X_RX	(93ul)
+#define PIN_SERIAL1X_TX	(94ul)
+#define PAD_SERIAL1X_RX	(SERCOM_RX_PAD_1)
+#define PAD_SERIAL1X_TX	(UART_TX_PAD_0)
+#define SERCOM_SERIAL1X	sercom4
+#define INTERRUPT_HANDLER_IMPLEMENT_SERIAL1X(uart) \
+	void SERCOM4_0_Handler() \
+	{ \
+		(uart).IrqHandler(); \
+	} \
+	void SERCOM4_1_Handler() \
+	{ \
+		(uart).IrqHandler(); \
+	} \
+	void SERCOM4_2_Handler() \
+	{ \
+		(uart).IrqHandler(); \
+	} \
+	void SERCOM4_3_Handler() \
+	{ \
+		(uart).IrqHandler(); \
+	}
 
 // Serial2
 #define PIN_SERIAL2_RX (83ul)
@@ -275,6 +319,23 @@ static const uint8_t DAC1 = PIN_DAC1;
 #define PAD_SERIAL2_RX (SERCOM_RX_PAD_1)
 #define PAD_SERIAL2_TX (UART_TX_PAD_0)
 #define SERCOM_SERIAL2 sercom1
+#define INTERRUPT_HANDLER_IMPLEMENT_SERIAL2(uart) \
+	void SERCOM1_0_Handler() \
+	{ \
+		(uart).IrqHandler(); \
+	} \
+	void SERCOM1_1_Handler() \
+	{ \
+		(uart).IrqHandler(); \
+	} \
+	void SERCOM1_2_Handler() \
+	{ \
+		(uart).IrqHandler(); \
+	} \
+	void SERCOM1_3_Handler() \
+	{ \
+		(uart).IrqHandler(); \
+	}
 
 /*
  * Wire Interfaces


### PR DESCRIPTION
Serial1x can communicate Raspberry Pi UART.

```
Uart Serial1x(&SERCOM_SERIAL1X, PIN_SERIAL1X_RX, PIN_SERIAL1X_TX, PAD_SERIAL1X_RX, PAD_SERIAL1X_TX);
INTERRUPT_HANDLER_IMPLEMENT_SERIAL1X(Serial1x)

void setup() {
  SerialUSB.begin(115200);
  Serial1x.begin(9600);
}

void loop() {
  while (Serial1x.available() >= 1)
  {
    SerialUSB.write(Serial1x.read());
  }
  while (SerialUSB.available() >= 1)
  {
    Serial1x.write(SerialUSB.read());
  }
}
```