### PR TITLE
Add CORE_HAS_LIBB64 definition

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -26,6 +26,8 @@
 #include <string.h>
 #include <math.h>
 
+#define CORE_HAS_LIBB64
+
 typedef bool boolean;
 typedef uint8_t byte;
 typedef uint16_t word;


### PR DESCRIPTION
Add a line to [**Arduino.h**](https://github.com/Seeed-Studio/ArduinoCore-samd/blob/master/cores/arduino/Arduino.h)

```
#define CORE_HAS_LIBB64
```

to avoid compiler's duplication errors