### PR TITLE
Fix some wrong register values

### DIFF
--- a/libraries/TimerTC3/TimerTC3.cpp
+++ b/libraries/TimerTC3/TimerTC3.cpp
@@ -88,7 +88,7 @@ void TimerTC3::setPeriod(long microseconds)
     while (TC->STATUS.bit.SYNCBUSY == 1)
         ;
 
-    TC->CC[0].reg = cycles;
+    TC->CC[0].reg = cycles - 1;
     while (TC->STATUS.bit.SYNCBUSY == 1)
         ;
 

--- a/libraries/TimerTCC0/TimerTCC0.cpp
+++ b/libraries/TimerTCC0/TimerTCC0.cpp
@@ -69,7 +69,7 @@ void TimerTCC0::setPeriod(long microseconds)
     
     //TC->CC[0].reg = cycles;
     //while(TC->SYNCBUSY.bit.CC0 == 1);
-    TC->PER.reg = cycles;              // Set counter Top using the PER register  
+    TC->PER.reg = cycles - 1;              // Set counter Top using the PER register  
     while (TC->SYNCBUSY.bit.PER == 1); // wait for sync 
     
 }


### PR DESCRIPTION
The function `setPeriod()` sets the wrong register value.
According to the [comment](https://github.com/Seeed-Studio/ArduinoCore-samd/blob/9e8beb1f8cb1d0a307a54dd5d4d7f60d0bb3bf39/libraries/TimerTC3/TimerTC3.cpp#L5), these timer library is inspired on the [khoih-prog/SAMD_TimerInterrupt](https://github.com/khoih-prog/SAMD_TimerInterrupt), which has the right code.

For TC3:
https://github.com/khoih-prog/SAMD_TimerInterrupt/blob/88c4a730ce3396cdf71f69936d24e6eb0d7f9b0a/src/SAMDTimerInterrupt.hpp#L424-L430 
https://github.com/khoih-prog/SAMD_TimerInterrupt/blob/88c4a730ce3396cdf71f69936d24e6eb0d7f9b0a/src/SAMDTimerInterrupt.hpp#L724-L730 
For TCC:
https://github.com/khoih-prog/SAMD_TimerInterrupt/blob/88c4a730ce3396cdf71f69936d24e6eb0d7f9b0a/src/SAMDTimerInterrupt.hpp#L810-L812