### PR TITLE
XIAO_m0/variant.h: Fix syntax error due to bee0a78a

### DIFF
--- a/variants/XIAO_m0/variant.h
+++ b/variants/XIAO_m0/variant.h
@@ -216,4 +216,4 @@ extern Uart Serial1;
 #define SERIAL_PORT_HARDWARE        Serial1
 #define SERIAL_PORT_HARDWARE_OPEN   Serial1
 
-#endif                  SerialUSB
+#endif


### PR DESCRIPTION
Commit bee0a78a left behind some code fragment which causes a syntax error. The compiler error message is:

```
.../Seeeduino/hardware/samd/1.8.4/variants/XIAO_m0/variant.h:219:25:
warning: extra tokens at end of #endif directive [-Wendif-labels]
```

The code that bee0a78a partially deleted was:

```
  #define Serial SerialUSB
```

I think the fix is to remove the whole thing, instead of adding it back, because I think TinyUSB provides its `Serial` instance. Verified to work on the XIAO M0 with this line removed.