### PR TITLE
Bump version to 1.8.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,5 +2,5 @@
     "name": "framework-arduino-samd-seeed",
     "description": "Arduino Core for SAMD21 and SAMD51 (Seeed Studio)",
     "url": "https://github.com/Seeed-Studio/ArduinoCore-samd",
-    "version": "1.8.5"
+    "version": "1.8.6"
 }

--- a/platform.txt
+++ b/platform.txt
@@ -20,7 +20,7 @@
 # https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5---3rd-party-Hardware-specification
 
 name=Seeed SAMD (32-bits ARM Cortex-M0+ and Cortex-M4) Boards
-version=1.8.5
+version=1.8.6
 
 # Compile variables
 # -----------------


### PR DESCRIPTION
## Summary
- Bump version from 1.8.5 to 1.8.6 in `package.json` and `platform.txt`

## Test plan
- [ ] Verify `pack.release.bash` generates correct `samd-1.8.6.tar.bz2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)